### PR TITLE
densify_polygons wasn't preserving columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Folders
 voronoi_diagram_for_polygons.egg-info/
 dist/
 build/
+.vscode/
+__pycache__/

--- a/longsgis/__init__.py
+++ b/longsgis/__init__.py
@@ -1,4 +1,1 @@
 from .longsgis import voronoiDiagram4plg
-from .longsgis import dropHoles
-from .longsgis import densify_polygon
-from .longsgis import minimum_distance

--- a/longsgis/longsgis.py
+++ b/longsgis/longsgis.py
@@ -1,160 +1,178 @@
-# -*- coding: utf-8 -*-
+"""Finds the approximate voronoi diagram generated around a polygon.
+
+Forked from https://github.com/longavailable/voronoi-diagram-for-polygons and last
+updated on updated on 2023/04/17.
 """
-* Updated on 2023/04/17
-* python3
-**
-* Geoprocessing in Python
-"""
-import pandas as pd
+
+import itertools
+import math
+
 import geopandas as gpd
 import numpy as np
 import shapely
+from shapely.geometry import MultiPolygon, Polygon
 from shapely.ops import voronoi_diagram as svd
-from shapely.geometry import Polygon, MultiPolygon
-import itertools, math
-import matplotlib.pyplot as plt
 
-def minimum_distance(gdf):
-	'''Calculate the minimum distance of all vertices of input geometries.
-	
-	Parameters:
-		gdf: polygons to be used
-			Type: geopandas.GeoDataFrame
-	Returns:
-		A float for the minimum distance.
-	'''
-	smp = gdf.unary_union	# convert to shapely.geometry.MultiPolygon
-	vertices = []
-	for g in smp.geoms:
-		coords = np.dstack(g.exterior.coords.xy).tolist()[0]	# vertices of each geometry
-		vertices = vertices + coords
-	potentials = list(itertools.combinations(vertices,2))	# pairs of vertices
-	all_distance = [math.sqrt((pp[0][0]-pp[1][0])**2+(pp[0][1]-pp[1][1])**2) for pp in potentials]	# calculate distance for each pair of vertices
-	nonzero_distance = [d for d in all_distance if d>0.0]	# drop zeros
-	return min(nonzero_distance)
-	
-def _pnts_on_line_(a, spacing=1, is_percent=False):  # densify by distance
-	"""Add points, at a fixed spacing, to an array representing a line.
-	Sourced from https://stackoverflow.com/a/65008592/12371819
 
-	**See**  `densify_by_distance` for documentation.
+def minimum_distance(gdf: gpd.GeoDataFrame) -> float:
+    """Calculate the minimum distance of all vertices of input geometries.
 
-	Parameters
-	----------
-	a : array
-		A sequence of `points`, x,y pairs, representing the bounds of a polygon
-		or polyline object.
-	spacing : number
-		Spacing between the points to be added to the line.
-	is_percent : boolean
-		Express the densification as a percent of the total length.
+    Args:
+        gdf (geopandas.GeoDataFrame): Polygons to be used.
 
-	Notes
-	-----
-	Called by `pnt_on_poly`.
-	"""
-	N = len(a) - 1                                    # segments
-	dxdy = a[1:, :] - a[:-1, :]                       # coordinate differences
-	leng = np.sqrt(np.einsum('ij,ij->i', dxdy, dxdy))  # segment lengths
-	if is_percent:                                    # as percentage
-		spacing = abs(spacing)
-		spacing = min(spacing / 100, 1.)
-		steps = (sum(leng) * spacing) / leng          # step distance
-	else:
-		steps = leng / spacing                        # step distance
-	deltas = dxdy / (steps.reshape(-1, 1))            # coordinate steps
-	pnts = np.empty((N,), dtype='O')                  # construct an `O` array
-	for i in range(N):              # cycle through the segments and make
-		num = np.arange(steps[i])   # the new points
-		pnts[i] = np.array((num, num)).T * deltas[i] + a[i]
-	a0 = a[-1].reshape(1, -1)       # add the final point and concatenate
-	return np.concatenate((*pnts, a0), axis=0)
+    Returns:
+        float: The minimum distance.
+    """
+    smp = gdf.unary_union  # convert to shapely.geometry.MultiPolygon
+    vertices = []
+    for g in smp.geoms:
+        coords = np.dstack(g.exterior.coords.xy).tolist()[
+            0
+        ]  # vertices of each geometry
+        vertices = vertices + coords
+    potentials = list(itertools.combinations(vertices, 2))  # pairs of vertices
+    all_distance = [
+        math.sqrt((pp[0][0] - pp[1][0]) ** 2 + (pp[0][1] - pp[1][1]) ** 2)
+        for pp in potentials
+    ]  # calculate distance for each pair of vertices
+    nonzero_distance = [d for d in all_distance if d > 0.0]  # drop zeros
+    return min(nonzero_distance)
 
-def densify_polygon(gdf, spacing='auto'):
-	'''Densify the vertex along the edge of polygon(s).
-	
-	Parameters:
-		gdf: polygons to be used
-			Type: geopandas.GeoDataFrame
-		spacing: type or distance to be used
-			Type: string, int, or float
-	Returns:
-		A set of new polygon(s) with more vertices.
-		Type: geopandas.GeoDataFrame
-	Raises:
-		ValueError: if spacing is not a string, int, or float.
-	'''
-	if not isinstance(spacing, (str, float, int)):
-		raise ValueError("Spacing must be a string, int, or float.")
 
-	if isinstance(spacing, str) and spacing.upper() == 'AUTO':
-		spacing = 0.25 * minimum_distance(gdf)	# less than 0.5? The less, the better?
+def _pnts_on_line_(a: np.ndarray, spacing: float = 1.0, is_percent: bool = False):
+    """Add points, at a fixed spacing, to an array representing a line.
 
-	# Create a geoseries containing lists of exterior points
-	ext_list = gdf["geometry"].map(lambda g: list(g.exterior.coords))
+    Sourced from https://stackoverflow.com/a/65008592/12371819.
 
-	# Add points to boundary of polygon
-	gdf["geometry"] = ext_list.map(
-		lambda x: Polygon(_pnts_on_line_(np.array(x),spacing=spacing))
-	)
+    Args:
+        a (numpy.ndarray): A sequence of points, x,y pairs, representing the bounds of a polygon or polyline object.
+        spacing (float, optional): Spacing between the points to be added to the line. Defaults to 1.
+        is_percent (bool, optional): Express the densification as a percent of the total length. Defaults to False.
 
-	# Drop the temp exterior point column
-	return gdf
+    Returns:
+        numpy.ndarray: Densified array of points.
+    """
+    N = len(a) - 1  # segments
+    dxdy = a[1:, :] - a[:-1, :]  # coordinate differences
+    leng = np.sqrt(np.einsum("ij,ij->i", dxdy, dxdy))  # segment lengths
+    if is_percent:  # as percentage
+        spacing = abs(spacing)
+        spacing = min(spacing / 100, 1.0)
+        steps = (sum(leng) * spacing) / leng  # step distance
+    else:
+        steps = leng / spacing  # step distance
+    deltas = dxdy / (steps.reshape(-1, 1))  # coordinate steps
+    pnts = np.empty((N,), dtype="O")  # construct an `O` array
+    for i in range(N):  # cycle through the segments and make
+        num = np.arange(steps[i])  # the new points
+        pnts[i] = np.array((num, num)).T * deltas[i] + a[i]
+    a0 = a[-1].reshape(1, -1)  # add the final point and concatenate
+    return np.concatenate((*pnts, a0), axis=0)
 
-def voronoiDiagram4plg(gdf, mask, densify=False, spacing='auto'):
-	'''Create Voronoi diagram / Thiessen polygons based on polygons.
-	
-	Parameters:
-		gdf: polygons to be used to create Voronoi diagram
-			Type: geopandas.GeoDataFrame
-		mask: polygon vector used to clip the created Voronoi diagram
-			Type: GeoDataFrame, GeoSeries, (Multi)Polygon
-	Returns:
-		gdf_vd: Thiessen polygons
-			Type: geopandas.geodataframe.GeoDataFrame
-	'''
-	gdf = gdf.copy()
-	if densify: gdf = densify_polygon(gdf, spacing=spacing)
-	gdf.reset_index(drop=True)
-	#convert to shapely.geometry.MultiPolygon
-	smp = gdf.unary_union
-	#create primary voronoi diagram by invoking shapely.ops.voronoi_diagram (new in Shapely 1.8.dev0)
-	smp_vd = svd(smp)
-	#convert to GeoSeries and explode to single polygons
-	#note that it is NOT supported to GeoDataFrame directly
-	gs = gpd.GeoSeries([smp_vd]).explode(index_parts=True)
 
-	# Fix any invalid polygons
-	gs.loc[~gs.is_valid] = gs.loc[~gs.is_valid].apply(lambda geom: geom.buffer(0))
+def densify_polygon(gdf: gpd.GeoDataFrame, spacing="auto"):
+    """Densify the vertex along the edge of polygon(s).
 
-	#convert to GeoDataFrame
-	#note that if gdf was shapely.geometry.MultiPolygon, it has no attribute 'crs'
-	gdf_vd_primary = gpd.geodataframe.GeoDataFrame(geometry=gs, crs=gdf.crs)
-	
-	#reset index
-	gdf_vd_primary.reset_index(drop=True)	#append(gdf)
+    Args:
+        gdf (geopandas.GeoDataFrame): Polygons to be used.
+        spacing (str, int, float, optional): Type or distance to be used. Defaults to 'auto'.
 
-	#spatial join by intersecting and dissolve by `index_right`
-	gdf_temp = ( gpd.sjoin(gdf_vd_primary, gdf, how='inner', predicate='intersects')
-		.dissolve(by='index_right').reset_index(drop=True) )
-	gdf_vd = gpd.clip(gdf_temp, mask)
-	gdf_vd['geometry'] = gdf_vd['geometry'].map(dropHoles)
-	return gdf_vd
+    Returns:
+        geopandas.GeoDataFrame: A set of new polygon(s) with more vertices.
 
-def dropHoles(plg):
-	'''Basic function to remove / drop / fill the holes.
-	
-	Parameters:
-		plg: plg who has holes / empties
-			Type: shapely.geometry.MultiPolygon or shapely.geometry.Polygon
-	Returns:
-		a shapely.geometry.MultiPolygon or shapely.geometry.Polygon object
-	'''
-	if isinstance(plg, MultiPolygon):
-		if shapely.__version__ < '2.0':
-			return MultiPolygon(Polygon(p.exterior) for p in plg)
-		else:
-			return MultiPolygon(Polygon(p.exterior) for p in plg.geoms)
-	elif isinstance(plg, Polygon):
-		return Polygon(plg.exterior)
+    Raises:
+        ValueError: If spacing is not a string, int, or float.
+    """
+    if not isinstance(spacing, str | float | int):
+        msg = "Spacing must be a string, int, or float."
+        raise TypeError(msg)
 
+    if isinstance(spacing, str) and spacing.upper() == "AUTO":
+        spacing = 0.25 * minimum_distance(gdf)  # less than 0.5? The less, the better?
+
+    # Create a geoseries containing lists of exterior points
+    ext_list = gdf["geometry"].map(lambda g: list(g.exterior.coords))
+
+    # Add points to boundary of polygon
+    gdf["geometry"] = ext_list.map(
+        lambda x: Polygon(_pnts_on_line_(np.array(x), spacing=spacing))
+    )
+
+    # Drop the temp exterior point column
+    return gdf
+
+
+def voronoiDiagram4plg(
+    gdf: gpd.GeoDataFrame,
+    mask,
+    densify: bool = False,
+    spacing="auto",
+) -> gpd.GeoDataFrame:
+    """Create Voronoi diagram / Thiessen polygons based on polygons.
+
+    Works on a copy of the input GeoDataFrame.
+
+    Args:
+        gdf (geopandas.GeoDataFrame): Polygons to be used to create Voronoi diagram.
+        mask (GeoDataFrame, GeoSeries, (Multi)Polygon): Polygon vector used to clip the created Voronoi diagram.
+        densify (bool, optional): Whether to densify the polygons. Defaults to False.
+        spacing (str, int, float, optional): Spacing for densification. Defaults to 'auto'.
+
+    Returns:
+        geopandas.GeoDataFrame: Thiessen polygons.
+    """
+    gdf = gdf.copy()
+    if densify:
+        gdf = densify_polygon(gdf, spacing=spacing)
+    gdf.reset_index(drop=True)
+
+    # convert to shapely.geometry.MultiPolygon
+    smp = gdf.unary_union
+
+    # create primary voronoi diagram by invoking shapely.ops.voronoi_diagram (new in Shapely 1.8.dev0)
+    smp_vd = svd(smp)
+
+    # convert to GeoSeries and explode to single polygons
+    # note that it is NOT supported to GeoDataFrame directly
+    gs = gpd.GeoSeries([smp_vd]).explode(index_parts=True)
+
+    # Fix any invalid polygons
+    gs.loc[~gs.is_valid] = gs.loc[~gs.is_valid].apply(lambda geom: geom.buffer(0))
+
+    # convert to GeoDataFrame
+    # note that if gdf was shapely.geometry.MultiPolygon, it has no attribute 'crs'
+    gdf_vd_primary = gpd.geodataframe.GeoDataFrame(geometry=gs, crs=gdf.crs)
+
+    # reset index
+    gdf_vd_primary.reset_index(drop=True)  # append(gdf)
+
+    # spatial join by intersecting and dissolve by `index_right`
+    gdf_temp = (
+        gpd.sjoin(gdf_vd_primary, gdf, how="inner", predicate="intersects")
+        .dissolve(by="index_right")
+        .reset_index(drop=True)
+    )
+    gdf_vd = gpd.clip(gdf_temp, mask)
+    gdf_vd["geometry"] = gdf_vd["geometry"].map(dropHoles)
+    return gdf_vd
+
+
+def dropHoles(
+    plg: (shapely.geometry.MultiPolygon | shapely.geometry.Polygon),
+) -> shapely.geometry.MultiPolygon | shapely.geometry.Polygon:
+    """Basic function to remove / drop / fill the holes.
+
+    Args:
+        plg (shapely.geometry.MultiPolygon or shapely.geometry.Polygon): Polygon with holes.
+
+    Returns:
+        shapely.geometry.MultiPolygon or shapely.geometry.Polygon: Polygon without holes.
+    """
+    if isinstance(plg, MultiPolygon):
+        if shapely.__version__ < "2.0":
+            return MultiPolygon(Polygon(p.exterior) for p in plg)
+        return MultiPolygon(Polygon(p.exterior) for p in plg.geoms)
+
+    if isinstance(plg, Polygon):
+        return Polygon(plg.exterior)
+    return None

--- a/longsgis/longsgis.py
+++ b/longsgis/longsgis.py
@@ -112,6 +112,7 @@ def voronoiDiagram4plg(gdf, mask, densify=False, spacing='auto'):
 		gdf_vd: Thiessen polygons
 			Type: geopandas.geodataframe.GeoDataFrame
 	'''
+	gdf = gdf.copy()
 	if densify: gdf = densify_polygon(gdf, spacing=spacing)
 	gdf.reset_index(drop=True)
 	#convert to shapely.geometry.MultiPolygon

--- a/longsgis/longsgis.py
+++ b/longsgis/longsgis.py
@@ -1,7 +1,7 @@
 """Finds the approximate voronoi diagram generated around a polygon.
 
 Forked from https://github.com/longavailable/voronoi-diagram-for-polygons and last
-updated on updated on 2023/04/17.
+updated on 2024/12/09. Updated from source 2024/12/09.
 """
 
 import itertools
@@ -52,7 +52,7 @@ def _pnts_on_line_(a: np.ndarray, spacing: float = 1.0, is_percent: bool = False
     Returns:
         numpy.ndarray: Densified array of points.
     """
-    N = len(a) - 1  # segments
+    n = len(a) - 1  # segments
     dxdy = a[1:, :] - a[:-1, :]  # coordinate differences
     leng = np.sqrt(np.einsum("ij,ij->i", dxdy, dxdy))  # segment lengths
     if is_percent:  # as percentage
@@ -62,15 +62,15 @@ def _pnts_on_line_(a: np.ndarray, spacing: float = 1.0, is_percent: bool = False
     else:
         steps = leng / spacing  # step distance
     deltas = dxdy / (steps.reshape(-1, 1))  # coordinate steps
-    pnts = np.empty((N,), dtype="O")  # construct an `O` array
-    for i in range(N):  # cycle through the segments and make
+    pnts = np.empty((n,), dtype="O")  # construct an `O` array
+    for i in range(n):  # cycle through the segments and make
         num = np.arange(steps[i])  # the new points
         pnts[i] = np.array((num, num)).T * deltas[i] + a[i]
     a0 = a[-1].reshape(1, -1)  # add the final point and concatenate
     return np.concatenate((*pnts, a0), axis=0)
 
 
-def densify_polygon(gdf: gpd.GeoDataFrame, spacing="auto"):
+def densify_polygon(gdf: gpd.GeoDataFrame, spacing="auto") -> gpd.GeoDataFrame:  # noqa: ANN001
     """Densify the vertex along the edge of polygon(s).
 
     Args:
@@ -95,7 +95,7 @@ def densify_polygon(gdf: gpd.GeoDataFrame, spacing="auto"):
 
     # Add points to boundary of polygon
     gdf["geometry"] = ext_list.map(
-        lambda x: Polygon(_pnts_on_line_(np.array(x), spacing=spacing))
+        lambda x: Polygon(_pnts_on_line_(np.array(x), spacing=spacing)),
     )
 
     # Drop the temp exterior point column
@@ -104,9 +104,9 @@ def densify_polygon(gdf: gpd.GeoDataFrame, spacing="auto"):
 
 def voronoiDiagram4plg(
     gdf: gpd.GeoDataFrame,
-    mask,
+    mask,  # noqa: ANN001
     densify: bool = False,
-    spacing="auto",
+    spacing="auto",  # noqa: ANN001
 ) -> gpd.GeoDataFrame:
     """Create Voronoi diagram / Thiessen polygons based on polygons.
 

--- a/longsgis/longsgis.py
+++ b/longsgis/longsgis.py
@@ -25,11 +25,14 @@ def minimum_distance(gdf: gpd.GeoDataFrame) -> float:
     """
     smp = gdf.unary_union  # convert to shapely.geometry.MultiPolygon
     vertices = []
-    for g in smp.geoms:
-        coords = np.dstack(g.exterior.coords.xy).tolist()[
-            0
-        ]  # vertices of each geometry
-        vertices = vertices + coords
+
+    if isinstance(smp, shapely.Polygon):
+        coords = np.dstack(smp.exterior.coords.xy).tolist()[0]
+        vertices.extend(coords)
+    else:
+        for g in smp.geoms:
+            coords = np.dstack(g.exterior.coords.xy).tolist()[0]
+            vertices.extend(coords)
     potentials = list(itertools.combinations(vertices, 2))  # pairs of vertices
     all_distance = [
         math.sqrt((pp[0][0] - pp[1][0]) ** 2 + (pp[0][1] - pp[1][1]) ** 2)
@@ -102,7 +105,7 @@ def densify_polygon(gdf: gpd.GeoDataFrame, spacing="auto") -> gpd.GeoDataFrame: 
     return gdf
 
 
-def voronoiDiagram4plg(
+def voronoiDiagram4plg(  # noqa: N802
     gdf: gpd.GeoDataFrame,
     mask,  # noqa: ANN001
     densify: bool = False,
@@ -157,7 +160,7 @@ def voronoiDiagram4plg(
     return gdf_vd
 
 
-def dropHoles(
+def dropHoles(  # noqa: N802
     plg: (shapely.geometry.MultiPolygon | shapely.geometry.Polygon),
 ) -> shapely.geometry.MultiPolygon | shapely.geometry.Polygon:
     """Basic function to remove / drop / fill the holes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ lint.ignore = [
     "PTH118",   # Should use Path rather than OS
     "PTH206",   # Should use Path rather than OS
     "PD901",    # df for dataframes
+    "FBT001",   # Boolean defaults
+    "FBT002",   # Boolean deafaults again
     ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,64 @@
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+lint.select = [
+    "ALL", # include all the rules, including new ones
+]
+
+lint.exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "archive*"
+]
+
+lint.ignore = [ 
+    "PT009",    # Assertion errors 
+    "TD",       # Errors with todos
+    "FIX001",   # Fixing HACKS
+    "FIX002",   # Suggestions to fix todos
+    "FIX004",   # Fixing FIXMEs
+    "PLR0913",  # Too many arguments
+    "ERA001",   # Commented out code
+    "D105",     # Docstrings in magic methods
+    "PERF401",  # Use list comprehension instead of for
+    "E501",     # Docstring line length
+    "RET504",   # Unecessary assignment before return
+    "ANN202",   # Return type for private function
+    "ANN204",   # Return type for magic function
+    "PTH110",   # Should use Path rathen than OS
+    "PTH118",   # Should use Path rather than OS
+    "PTH206",   # Should use Path rather than OS
+    "PD901",    # df for dataframes
+    ]
+
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D", "ANN201", "PT", "SLF001"] # Docstrings etc.
+"download.py" = ["T201"] # Print statements
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"

--- a/tests/test_longsgis.py
+++ b/tests/test_longsgis.py
@@ -1,8 +1,9 @@
 import unittest
 import warnings
 
-from shapely.geometry import Polygon
 import geopandas as gpd
+from shapely.geometry import Polygon
+
 from longsgis import densify_polygon
 
 

--- a/tests/test_longsgis.py
+++ b/tests/test_longsgis.py
@@ -1,0 +1,52 @@
+import unittest
+import warnings
+
+from shapely.geometry import Polygon
+import geopandas as gpd
+from longsgis import densify_polygon
+
+
+class TestDensifyPolygon(unittest.TestCase):
+    def setUp(self):
+        warnings.simplefilter(
+            "ignore",
+            category=DeprecationWarning,
+        )  # HACK geopandas warning suppression for testing
+
+    def test_densify_polygon(self):
+        # Create a sample GeoDataFrame with a simple polygon
+        p1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]).normalize()
+        p2 = Polygon([(2, 2), (3, 2), (3, 3), (2, 3), (2, 2)]).normalize()
+        gdf = gpd.GeoDataFrame(
+            {"geometry": [p1, p2], "test_col1": ["a", "b"], "test_col2": ["c", "d"]},
+            crs="EPSG:3857",
+        )
+
+        densified_gdf = densify_polygon(gdf.copy(), spacing=0.1)
+
+        # Original columns should be preservered
+        self.assertTrue(all(col in densified_gdf.columns for col in gdf.columns))
+
+        # Check that the densified polygons are correct
+        for i, r in densified_gdf.iterrows():
+            with self.subTest(i=i, r=r):
+                densified = r["geometry"]
+                original = gdf.iloc[i]["geometry"]
+
+                # Densified polygons should be valid, simple, and have the same area
+                self.assertTrue(densified.is_valid)
+                self.assertTrue(densified.is_simple)
+                self.assertAlmostEqual(densified.area, original.area)
+
+                # Polygons should be the same (after simplification)
+                simplified_densified = densified.simplify(
+                    tolerance=0.01, preserve_topology=True
+                ).normalize()
+                self.assertTrue(
+                    simplified_densified.equals_exact(original, tolerance=1e-6)
+                )
+
+                # Densified polygons should have more vertices
+                self.assertGreater(
+                    len(densified.exterior.coords), len(original.exterior.coords)
+                )


### PR DESCRIPTION
Changes in this pull request:

1. I've re-written `densify_polygons` so that it doesn't drop any of the original columns. Before, it was just returning a gdf with one column ("geometry"). Because of this, calling `voronoiDiagram4plg`  with densify=True was returning a gdf with different columns than if you used densify=False. Now it will return the input gdf with only the "geometry" column updated.
2. `densify_polygons` now throws a Value Error if `spacing` is not defined correctly.
3. I added some unittests for `densify_polygons`. These can be run with `python -m unittest tests.test_longsgis`
4. I changed `voronoiDiagram4plg` to use work on a *copy* of the input gdf